### PR TITLE
Headless endpoint error

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -103,6 +103,6 @@ class DefaultController extends Controller {
      */
     public function actionApi($limit = 25, $siteId = 0, $url = '') {
         header('Content-type:application/json;charset=utf-8');
-        echo json_encode(Craftagram::$plugin->craftagramService->getInstagramFeed($limit, $siteId, $url));
+        return json_encode(Craftagram::$plugin->craftagramService->getInstagramFeed($limit, $siteId, $url));
     }
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -103,6 +103,7 @@ class DefaultController extends Controller {
      */
     public function actionApi($limit = 25, $siteId = 0, $url = '') {
         header('Content-type:application/json;charset=utf-8');
-        return json_encode(Craftagram::$plugin->craftagramService->getInstagramFeed($limit, $siteId, $url));
+        echo json_encode(Craftagram::$plugin->craftagramService->getInstagramFeed($limit, $siteId, $url));
+        die();
     }
 }


### PR DESCRIPTION
I'm finding when fetching the headless endpoint at `/actions/craftagram/default/api` my JSON parse fails.

Perhaps because I'm in development mode, but I'm seeing the following error returned alongside the JSON:
```
<pre>An Error occurred while handling another error:
yii\web\HeadersAlreadySentException: Headers already sent in /var/www/craft/vendor/scaramangagency/craftagram/src/controllers/DefaultController.php on line 106. in /var/www/craft/vendor/yiisoft/yii2/web/Response.php:366
Stack trace:
#0 /var/www/craft/vendor/yiisoft/yii2/web/Response.php(339): yii\web\Response-&gt;sendHeaders()
#1 /var/www/craft/vendor/yiisoft/yii2/web/ErrorHandler.php(136): yii\web\Response-&gt;send()
#2 /var/www/craft/vendor/craftcms/cms/src/web/ErrorHandler.php(147): yii\web\ErrorHandler-&gt;renderException()
#3 /var/www/craft/vendor/yiisoft/yii2/base/ErrorHandler.php(135): craft\web\ErrorHandler-&gt;renderException()
#4 /var/www/craft/vendor/craftcms/cms/src/web/ErrorHandler.php(63): yii\base\ErrorHandler-&gt;handleException()
#5 [internal function]: craft\web\ErrorHandler-&gt;handleException()
#6 {main}
Previous exception:
yii\web\NotFoundHttpException: Page not found. in /var/www/craft/vendor/craftcms/cms/src/web/Request.php:1250
Stack trace:
#0 /var/www/craft/vendor/yiisoft/yii2/web/Application.php(82): craft\web\Request-&gt;resolve()
#1 /var/www/craft/vendor/craftcms/cms/src/web/Application.php(259): yii\web\Application-&gt;handleRequest()
#2 /var/www/craft/vendor/yiisoft/yii2/base/Application.php(386): craft\web\Application-&gt;handleRequest()
#3 /var/www/craft/web/index.php(22): yii\base\Application-&gt;run()
#4 {main}</pre>
```

Looking at the DefaultController, I think this to be because there is no `return` or `die()` in the API action. So it goes on to look for a template to render.