### PR TITLE
feat: multi-site support for refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # craftagram Changelog
 
-### Unreleased
+## 1.4.6 - 2023-02-06
+- Fix parseEnv deprecation
 - Update cron example in README.txt (thanks @Ottergoose)
 - Casing of plugin title in sidebar
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Grab Instagram content through the Instagram Basic Display API
 
 ## Requirements
 
-This plugin requires Craft CMS 3.1.0 or later.
+This plugin requires Craft CMS 3.7.29 or later.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,43 @@ For example, this would run the token refresh every month
 0 0 1 * * /usr/bin/wget -q https://www.yourwebsite.com/actions/craftagram/default/refresh-token >/dev/null 2>&1
 ```
 
-If you fail to set up the cron, you can still refresh the token manaully, by going to the settings page, clicking the `Authorise Craft` and following the steps outlined above.
+You can also skip triggering the refresh over HTTP and call the CLI command `craft craftagram/token`.
+
+Which in cron can be configured as: 
+
+```
+0 0 1 * * php /path/to/your/code/craft craftagram/token >/dev/null 2>&1
+```
+
+#### Multi-site setup
+In a multi-site setup it is possible to configure different Instagram apps per domain. This also means the refresh of tokens needs to be configured different from a single site Craft CMS setup.
+
+The examples assume that two sites are configured, as follows:
+
+|ID|Domain
+|---|---
+| 1  |www.example.com
+| 2  |bar.example.com
+
+The refresh action will use the Craft CMS current site logic to determine for which site to refresh the token.
+
+So for example when refreshing your sites with the domains "www.example.com" and "bar.example.com" over the HTTP refresh action use:
+
+```
+0 0 1 * * /usr/bin/wget -q https://www.example.com/actions/craftagram/default/refresh-token >/dev/null 2>&1
+
+0 0 1 * * /usr/bin/wget -q https://bar.example.com/actions/craftagram/default/refresh-token >/dev/null 2>&1
+```
+
+The console command accepts a site ID as first argument. So to fresh both "www.example.com" and "bar.example.com" use:
+
+```
+0 0 1 * * php /path/to/your/code/craft craftagram/token 1 >/dev/null 2>&1
+
+0 0 1 * * php /path/to/your/code/craft craftagram/token 2 >/dev/null 2>&1
+```
+
+If you fail to set up the cron, you can still refresh the token manually, by going to the settings page, clicking the `Authorise Craft` and following the steps outlined above.
 
 > :warning: You cannot refresh access tokens for private Instagram accounts, so ensure the account used in your tester invite above is public
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "scaramangagency/craftagram",
     "description": "Grab Instagram content through the Instagram Basic Display API",
     "type": "craft-plugin",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "keywords": [
         "craft",
         "cms",
@@ -22,12 +22,12 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.1.0",
+        "craftcms/cms": "^3.7.29",
         "putyourlightson/craft-log-to-file": "^1.0.0"
     },
     "autoload": {
         "psr-4": {
-          "scaramangagency\\craftagram\\": "src/"
+            "scaramangagency\\craftagram\\": "src/"
         }
     },
     "extra": {

--- a/src/console/controllers/TokenController.php
+++ b/src/console/controllers/TokenController.php
@@ -10,9 +10,11 @@
 
 namespace scaramangagency\craftagram\console\controllers;
 
+use Craft;
 use scaramangagency\craftagram\Craftagram;
 
 use craft\console\Controller;
+use yii\console\ExitCode;
 
 
 class TokenController extends Controller {
@@ -23,8 +25,18 @@ class TokenController extends Controller {
     /**
      * Refreshes Instagram Token.
      */
-    public function actionIndex()
+    public function actionIndex(?int $siteId = null)
     {
-        return Craftagram::$plugin->craftagramService->refreshToken();
+        if (!$siteId) {
+            $siteId = (int) Craft::$app->getSites()->getPrimarySite()->id;
+        }
+
+        $result = Craftagram::$plugin->craftagramService->refreshToken($siteId);
+
+        if (true === $result) {
+            return ExitCode::OK;
+        }
+
+        return ExitCode::UNSPECIFIED_ERROR;
     }
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -12,7 +12,6 @@ namespace scaramangagency\craftagram\controllers;
 
 use craft\helpers\App;
 use scaramangagency\craftagram\Craftagram;
-use scaramangagency\craftagram\services\CraftagramService;
 
 use Craft;
 use craft\web\Controller;
@@ -38,14 +37,20 @@ class DefaultController extends Controller {
 
     // Public Methods
     // =========================================================================
-    
+
     /**
-     * Refresh the instragram token
+     * Refresh the instagram token
      *
      * @return bool
      */
     public function actionRefreshToken() {
-        return Craftagram::$plugin->craftagramService->refreshToken();
+        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+
+        return Craftagram::$plugin
+            ->craftagramService
+            ->refreshToken(
+                (int) $siteId
+            );
     }
 
     /**
@@ -68,7 +73,7 @@ class DefaultController extends Controller {
      */
     public function actionAuth() {
         $url = parse_url(rtrim(App::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . $_SERVER['REQUEST_URI']);
-        parse_str($url['query'], $params); 
+        parse_str($url['query'], $params);
         $code = $params['code'];
         $siteId = $params['state'];
 

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -10,6 +10,7 @@
 
 namespace scaramangagency\craftagram\controllers;
 
+use craft\helpers\App;
 use scaramangagency\craftagram\Craftagram;
 use scaramangagency\craftagram\services\CraftagramService;
 
@@ -53,8 +54,8 @@ class DefaultController extends Controller {
      * @return Response
      */
     public function actionHandleAuth($site_id, $client_id) {
-        $url = rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/'); 
-        $appId = Craft::parseEnv($client_id);
+        $url = rtrim(App::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/');
+        $appId = App::parseEnv($client_id);
 
         Craft::$app->getResponse()->redirect('https://api.instagram.com/oauth/authorize?client_id='.$appId.'&scope=user_profile,user_media&response_type=code&redirect_uri='.$url.'/actions/craftagram/default/auth&state='.$site_id)->send();
         exit;
@@ -66,7 +67,7 @@ class DefaultController extends Controller {
      * @return Response|null
      */
     public function actionAuth() {
-        $url = parse_url(rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . $_SERVER['REQUEST_URI']); 
+        $url = parse_url(rtrim(App::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . $_SERVER['REQUEST_URI']);
         parse_str($url['query'], $params); 
         $code = $params['code'];
         $siteId = $params['state'];

--- a/src/services/CraftagramService.php
+++ b/src/services/CraftagramService.php
@@ -18,6 +18,7 @@ use craft\base\Component;
 use craft\services\Plugins;
 use putyourlightson\logtofile\LogToFile;
 use craft\helpers\Db;
+use craft\helpers\App;
 
 class CraftagramService extends Component {
 
@@ -121,10 +122,10 @@ class CraftagramService extends Component {
         $longAccessTokenRecord = SettingsRecord::findOne($getSettings);
 
         $params = [
-            'client_id' => Craft::parseEnv($longAccessTokenRecord->appId),
-            'client_secret' => Craft::parseEnv($longAccessTokenRecord->appSecret),
+            'client_id' => App::parseEnv($longAccessTokenRecord->appId),
+            'client_secret' => App::parseEnv($longAccessTokenRecord->appSecret),
             'grant_type' => 'authorization_code',
-            'redirect_uri' => rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . '/actions/craftagram/default/auth',
+            'redirect_uri' => rtrim(App::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . '/actions/craftagram/default/auth',
             'code' => $code
         ];
 
@@ -151,7 +152,7 @@ class CraftagramService extends Component {
         $ch = curl_init();
 
         $params = [
-            'client_secret' => Craft::parseEnv($secret),
+            'client_secret' => App::parseEnv($secret),
             'grant_type' => 'ig_exchange_token',
             'access_token' => $shortAccessToken
         ];

--- a/src/templates/settings/index.twig
+++ b/src/templates/settings/index.twig
@@ -129,7 +129,9 @@
             {% endfor %}
         </div>
 
-        <a data-after="{{ craftagram.paging.cursors.after }}" data-js="load-more" class="btn">Load more</a>
+        {% if craftagram.paging is defined %}
+            <a data-after="{{ craftagram.paging.cursors.after }}" data-js="load-more" class="btn">Load more</a>
+        {% endif %}
     {% endif %}
 
 {% endset %}


### PR DESCRIPTION
The previous implementation of the CraftagramService would exit if the first site did not have a configured long access token. 

It would also return `true` if the API call to Instagram failed. 

The console controller returned the raw bool value as well, which mean that `true` gets converted to `1` which shells interpret as "exited with an error". 

Also fix some typos and unused namespace imports.

I know this breaks the previous behavior but I thought this might be more in line with the intended behavior. I made this PR for Craft 3 branch still, as the project I'm working on is still on 3.8. I'd be happy to also create this style PR for the v2 branch. 