### PR TITLE
Feature+Bugfixes considering Multi-Site Support and Console Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,16 @@ Instagram may challenge you with a login screen, so handle that, then click 'Aut
 
 Instagram tokens expire in 60 days, so you'll need to set up a cron job to keep the token alive. The refresh action is `actions/craftagram/default/refresh-token`.
 
-For example, this would run the token refresh every month
+For example, this would run the token refresh every month, for all enabled sites with tokens
 
 ```
 0 0 1 * * /usr/bin/wget -q https://www.yourwebsite.com/actions/craftagram/default/refresh-token >/dev/null 2>&1
+```
+
+If you just want to update a single site you can add the optional param `siteId`
+
+```
+0 0 1 * * /usr/bin/wget -q https://www.yourwebsite.com/actions/craftagram/default/refresh-token?siteId=<your siteId> >/dev/null 2>&1
 ```
 
 If you fail to set up the cron, you can still refresh the token manaully, by going to the settings page, clicking the `Authorise Craft` and following the steps outlined above.

--- a/src/Craftagram.php
+++ b/src/Craftagram.php
@@ -60,7 +60,7 @@ class Craftagram extends Plugin {
      * @var bool
      */
     public bool $hasCpSection = true;
-    
+
     /**
      * @var bool
      */
@@ -87,7 +87,7 @@ class Craftagram extends Plugin {
         );
 
         Event::on(
-            UrlManager::class, 
+            UrlManager::class,
             UrlManager::EVENT_REGISTER_CP_URL_RULES,
             function(RegisterUrlRulesEvent $event) {
                 $event->rules = array_merge($event->rules, [

--- a/src/console/controllers/TokenController.php
+++ b/src/console/controllers/TokenController.php
@@ -13,7 +13,7 @@ namespace scaramangagency\craftagram\console\controllers;
 use scaramangagency\craftagram\Craftagram;
 
 use craft\console\Controller;
-
+use yii\console\ExitCode;
 
 class TokenController extends Controller {
 
@@ -21,10 +21,21 @@ class TokenController extends Controller {
     // =========================================================================
 
     /**
-     * Refreshes Instagram Token.
+     * Refreshes Instagram long access token(s).
+     *
+     * @param  string|null $siteId if a siteId is given, update this site only
+     * @return ExitCode 0 = OK, 1 = failed to refesh tokens for one or more sites
      */
-    public function actionIndex()
+    public function actionIndex(?int $siteId = null)
     {
-        return Craftagram::$plugin->craftagramService->refreshToken();
+        if ($siteId) {
+            $sucess = Craftagram::$plugin->craftagramService->refreshTokenForSiteId($siteId);
+        } else {
+            $sucess = Craftagram::$plugin->craftagramService->refreshToken();
+        }
+
+        return $sucess
+            ? ExitCode::OK
+            : ExitCode::UNSPECIFIED_ERROR;
     }
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -39,11 +39,19 @@ class DefaultController extends Controller {
     // =========================================================================
 
     /**
-     * Refresh the instragram token
+     * Refresh the instragram token for all enabled sites
+     * or for a specific one if param siteId is given
      *
-     * @return bool
+     * @param  integer $siteId siteId to refresh the long access token for
+     * @return bool true if successful, otherwise false
      */
     public function actionRefreshToken() {
+        $siteId = Craft::$app->getRequest()->getParam('siteId', null);
+
+        if ($siteId) {
+            return Craftagram::$plugin->craftagramService->refreshTokenForSiteId((int) $siteId);
+        }
+
         return Craftagram::$plugin->craftagramService->refreshToken();
     }
 

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -37,7 +37,7 @@ class DefaultController extends Controller {
 
     // Public Methods
     // =========================================================================
-    
+
     /**
      * Refresh the instragram token
      *
@@ -53,7 +53,7 @@ class DefaultController extends Controller {
      * @return Response
      */
     public function actionHandleAuth($site_id, $client_id) {
-        $url = rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/'); 
+        $url = rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/');
         $appId = Craft::parseEnv($client_id);
 
         Craft::$app->getResponse()->redirect('https://api.instagram.com/oauth/authorize?client_id='.$appId.'&scope=user_profile,user_media&response_type=code&redirect_uri='.$url.'/actions/craftagram/default/auth&state='.$site_id)->send();
@@ -66,8 +66,8 @@ class DefaultController extends Controller {
      * @return Response|null
      */
     public function actionAuth() {
-        $url = parse_url(rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . $_SERVER['REQUEST_URI']); 
-        parse_str($url['query'], $params); 
+        $url = parse_url(rtrim(Craft::parseEnv(Craft::$app->sites->primarySite->baseUrl), '/') . $_SERVER['REQUEST_URI']);
+        parse_str($url['query'], $params);
         $code = $params['code'];
         $siteId = $params['state'];
 

--- a/src/services/CraftagramService.php
+++ b/src/services/CraftagramService.php
@@ -102,10 +102,12 @@ class CraftagramService extends Component {
                 Craftagram::$plugin->log('Successfully refreshed authentication token. Expires in ' . $expires);
             } catch (Exception $e) {
                 Craftagram::$plugin->log('Failed to refresh authentication token. Error: ' . $res, LogLevel:ERROR);
+                return false;
             }
 
-            return true;
         }
+
+        return true;
     }
 
     /**

--- a/src/services/CraftagramService.php
+++ b/src/services/CraftagramService.php
@@ -32,7 +32,7 @@ class CraftagramService extends Component {
             'craftagramSiteId' => $siteId
         ];
 
-        $longAccessTokenRecord = SettingsRecord::findOne($params); 
+        $longAccessTokenRecord = SettingsRecord::findOne($params);
 
         if (!$longAccessTokenRecord) {
             Craftagram::$plugin->log('An access token has not been obtained from Instagram');
@@ -57,7 +57,7 @@ class CraftagramService extends Component {
             'craftagramSiteId' => $siteId
         ];
 
-        $isSecured = SettingsRecord::findOne($params); 
+        $isSecured = SettingsRecord::findOne($params);
 
         if (!$isSecured) {
             Craftagram::$plugin->log('This site does not have a linked instagram account');
@@ -75,35 +75,35 @@ class CraftagramService extends Component {
     public function refreshToken() {
         $siteIds = Craft::$app->sites->getAllSiteIds();
 
-        
+
         foreach ($siteIds as $siteId) {
             $longAccessTokenRecord = Craftagram::$plugin->craftagramService->getLongAccessTokenSetting($siteId);
-    
+
             if (!$longAccessTokenRecord) {
                 return false;
             }
-    
+
             $ch = curl_init();
-            
+
             $params = [
                 'access_token' => $longAccessTokenRecord,
                 'grant_type' => 'ig_refresh_token'
             ];
-    
+
             curl_setopt($ch, CURLOPT_URL,'https://graph.instagram.com/refresh_access_token?'.http_build_query($params));
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-    
+
             $res = curl_exec($ch);
             curl_close($ch);
-    
+
             try {
                 $expires = json_decode($res)->expires_in;
                 Craftagram::$plugin->log('Successfully refreshed authentication token. Expires in ' . $expires);
             } catch (Exception $e) {
                 Craftagram::$plugin->log('Failed to refresh authentication token. Error: ' . $res, LogLevel:ERROR);
             }
-    
+
             return true;
         }
     }
@@ -144,7 +144,7 @@ class CraftagramService extends Component {
 
     /**
      * Get long access token from instagram and save it
-     * 
+     *
      * @return string
      */
     public function getLongAccessToken($shortAccessToken, $siteId, $secret) {
@@ -177,15 +177,15 @@ class CraftagramService extends Component {
             $longAccessTokenRecord->setAttribute('longAccessToken', $token);
             $longAccessTokenRecord->save();
         }
-        
+
         return $token;
     }
 
     /**
      * Get instagram feed
-     * 
+     *
      * @return string|null
-     */    
+     */
     public function getInstagramFeed($limit, $siteId, $after) {
 
         if ($siteId == 0) {
@@ -206,7 +206,7 @@ class CraftagramService extends Component {
             'limit' => $limit
         ];
 
-        
+
         if ($after != '') {
             $params['after'] = $after;
         }
@@ -223,13 +223,13 @@ class CraftagramService extends Component {
         if (!isset($res->data)) {
             Craftagram::$plugin->log('Failed to get data. Response from Instagram: ' . json_encode($res));
         }
-        
+
         return (isset($res->data) ? $res : null);
     }
 
     /**
      * Get instagram feed
-     * 
+     *
      * @return mixed
      */
     public function handleAuthentication()
@@ -255,9 +255,9 @@ class CraftagramService extends Component {
 
     /**
      * Get profile information
-     * 
+     *
      * @return string|null
-     */ 
+     */
     public function getProfileMeta($username) {
         try {
 
@@ -272,7 +272,7 @@ class CraftagramService extends Component {
             curl_close($ch);
 
             $res = json_decode($res);
-            
+
             $meta = null;
 
             if (isset($res->graphql)) {
@@ -294,5 +294,5 @@ class CraftagramService extends Component {
         }
     }
 
-    
+
 }


### PR DESCRIPTION
### Description

Similar to PR: #63, but targets `v2` branch for Craft4.
best to Review both and pick what you need.

**Changes have been done in mind to not break the existing API.**

For easier Review, the changes are split in several commits addressing the corresponding issues.

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### What is this pull request trying to solve?

- Fixes Bug when having multiple Sites configured in Craft and different Instagram Accounts connected to it, only the first long access token is refreshed
- Fixes Bug when using the console Command `craftagram/token/index` to refresh the tokens, the ExitCode of the Console Command is `1` when the command finished successful, which should be by convention ExitCode of 0)
- Add feature to optionally pass a `siteId` to console Command `craftagram/token/index` to target a specific site only, call without the optional `siteId` will refesh all tokens.
- Add feature to update tokens via the Web Controller on a per Site basis when passing the optional `siteId` param.

### Known Issues

- when configuring the same Instagram Account for different Sites refreshToken() will contact the Instagram API multiple times